### PR TITLE
refactor:같은 제품 한번만 리스트 랜더링 하게 수정

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,15 +3,15 @@ const nextConfig = {
   async rewrites() {
     return [
       {
-        source: '/api/samsung',
+        source: '/api/1',
         destination: `http://want2u.duckdns.org/main/1`,
       },
       {
-        source: '/api/apple',
+        source: '/api/2',
         destination: `http://want2u.duckdns.org/main/2`,
       },
       {
-        source: '/api/lg',
+        source: '/api/3',
         destination: `http://want2u.duckdns.org/main/3`,
       },
     ];

--- a/src/components/List.tsx
+++ b/src/components/List.tsx
@@ -1,33 +1,45 @@
 import styled from 'styled-components';
 import Btn from './Btn';
+import axios from 'axios';
+import { List as dataList } from '../constant';
+import { useEffect, useState } from 'react';
+const List = ({ typeofList }: { typeofList: number }) => {
+  const [lists, setLists] = useState<dataList[]>([]);
 
-const List = () => {
+  const getUniqueArray = (array: Object) => {
+    const newArray = Object.entries(array);
+    const newdataArray: dataList[] = [];
+    newArray.forEach((each, index) => {
+      if (index % 4 == 0) {
+        newdataArray.push(each[1]);
+      }
+    });
 
+    return newdataArray;
+  };
+
+  useEffect(() => {
+    const url = '/api/' + String(typeofList);
+    const getResponse = async () => {
+      const ListData = await axios.get(url);
+      return ListData;
+    };
+    getResponse().then((res) => {
+      setLists(res.data);
+      setLists(getUniqueArray(res.data));
+    });
+    getResponse().catch((err) => console.log(err));
+  }, []);
   return (
     <Container>
       <StyledGrid>
-        <Item>
-          <Btn imgSrc="./g_book2.webp" name="갤럭시 북2" />
-        </Item>
-        <Item>
-          <Btn imgSrc="./g_book2pro360.webp" name="갤럭시 북2 Pro" />
-        </Item>
-        <Item>
-          <Btn imgSrc="./g_book2pro.webp" name="갤럭시 북2 Pro360" />
-        </Item>
-        <Item>
-          <Btn imgSrc="./g_taps8.avif" name="갤럭시 탭 S8" />
-        </Item>
-        <Item>
-          <Btn imgSrc="./g_taps8+.webp" name="갤럭시 탭 S8+" />
-        </Item>
-        <Item>
-          <Btn imgSrc="./g_tapa8.avif" name="갤럭시 탭 A8" />
-        </Item>
+        {lists.map((list, index) => (
+          <Item key={list.id}>{list.name}</Item>
+        ))}
       </StyledGrid>
     </Container>
   );
-}
+};
 
 export default List;
 
@@ -46,7 +58,7 @@ const StyledGrid = styled.div`
   gap: 3rem;
   margin-top: 3rem;
 
-  @media(max-width: 800px) {
+  @media (max-width: 800px) {
     grid-template-rows: 30vw 30vw;
   }
 `;
@@ -56,7 +68,6 @@ const Item = styled.div`
   justify-content: center;
   align-items: center;
   gap: 15px;
-
   border-radius: 1rem;
   box-shadow: 0px 5px 5px rgba(158, 158, 158, 1);
   background-color: white;

--- a/src/constant.ts
+++ b/src/constant.ts
@@ -1,6 +1,17 @@
 interface Props {
-    imgSrc: string,
-    name: string,
+  imgSrc: string;
+  name: string;
 }
 
-export type { Props };
+interface List {
+  id: number;
+  link: string[];
+  name: string;
+  price: number;
+}
+
+interface ListArray {
+  Store: List[];
+}
+
+export type { Props, ListArray, List };

--- a/src/pages/a_list.tsx
+++ b/src/pages/a_list.tsx
@@ -5,24 +5,16 @@ import List from '../components/List';
 import Nav from '../components/Nav';
 
 const A_list = () => {
-
-  useEffect(() => {
-    const getapi = async () => {
-      const getdata = await axios.get('/api/apple').then((res) => console.log(res));
-    }
-    getapi();
-  }, [])
-
   return (
     <div>
       <Nav />
       <StyledDiv>
         <StyledH1>Apple</StyledH1>
-        <List />
+        <List typeofList={2} />
       </StyledDiv>
     </div>
   );
-}
+};
 
 export default A_list;
 

--- a/src/pages/l_list.tsx
+++ b/src/pages/l_list.tsx
@@ -5,23 +5,16 @@ import List from '../components/List';
 import Nav from '../components/Nav';
 
 const A_list = () => {
-  useEffect(() => {
-    const getapi = async () => {
-      const getdata = await axios.get('/api/lg').then((res) => console.log(res));
-    }
-    getapi();
-  }, [])
-
   return (
     <div>
       <Nav />
       <StyledDiv>
         <StyledH1>LG</StyledH1>
-        <List />
+        <List typeofList={3} />
       </StyledDiv>
     </div>
   );
-}
+};
 
 export default A_list;
 

--- a/src/pages/s_list.tsx
+++ b/src/pages/s_list.tsx
@@ -5,32 +5,24 @@ import List from '../components/List';
 import Nav from '../components/Nav';
 
 interface Item {
-  id: number,
-  name: string,
-  maker_id: number,
-  price: number,
-  link: string,
+  id: number;
+  name: string;
+  maker_id: number;
+  price: number;
+  link: string;
 }
 
 const S_list = () => {
-
-  useEffect(() => {
-    const getapi = async () => {
-      const getdata = await axios.get('/api/samsung').then((res) => console.log(res));
-    }
-    getapi();
-  }, [])
-
   return (
     <div>
       <Nav />
       <StyledDiv>
         <StyledH1>SAMSUNG</StyledH1>
-        <List />
+        <List typeofList={1} />
       </StyledDiv>
     </div>
   );
-}
+};
 
 export default S_list;
 


### PR DESCRIPTION
바뀐 부분:

기존 같은 제품이 여러번 랜더링 되었으나, 같은 제품은 한번만 랜더링 되게 수정 ⭐ 
![image](https://user-images.githubusercontent.com/59411107/215325928-86ab17f3-a406-456b-9cda-2b636e62d97c.png)


바뀌어야 할 부분:
이미지 추가, 마지막 detail 페이지 마무리
